### PR TITLE
Add firmware, description of ZeroMQ interface, and IO channel info

### DIFF
--- a/Documentation/PIX0MQ_protocol.md
+++ b/Documentation/PIX0MQ_protocol.md
@@ -1,0 +1,84 @@
+ZeroMQ protocol for PIX0MQ communications
+=====================
+
+Commands and acknowledgements are sent via a REQ-REP socket pair. Data
+is broadcast via a PUB socket on the board and received via SUB.
+
+Commands
+--------
+
+### Packets
+
+Packets can be sent to LArPix with a REQ command:
+
+```
+SNDWORD 0x<16-hex-digit word> <IO Chain ID>
+```
+
+As an example:
+
+```
+SNDWORD 0x0020000000000003 0
+```
+
+sends the command to read configuration register 0.
+
+The control board will reply with either `OK` or `ERR`.
+
+### Clock
+
+The clock frequency can be set with the command:
+
+```
+SETFREQ 0x<frequency>
+```
+
+Frequency is the hex representation of the frequency in kHz. The minimum
+frequency is 5 MHz (0x1388). The maximum frequency is 25 MHz (0x61a8).
+
+Response is `OK` or `ERR`.
+
+### Test pulse divider
+
+Set the frequency of the onboard test pulse LEMO (TST).
+
+```
+SETFTST 0x<div>
+```
+
+The new frequency will be equal to the clock frequency (CLK2X) divided
+by the `div` value specified in the command.
+
+Response is `OK` or `ERR`.
+
+### Low-level stats
+
+Retrieves the number of start and stop bits received since the last
+system reset (the numbers should be
+equal and represent the number of packets).
+
+```
+GETSTAT <channel>
+```
+
+Response is `<starts> <stops>`
+
+### System reset
+
+Send the reset signal to LArPix.
+
+```
+SYRESET
+```
+
+Response is `OK` or `ERR`.
+
+### Ping
+
+Ask system if it is still alive
+
+```
+PING_HB
+```
+
+Response is `OK` if all is good. Any other response indicates an error.

--- a/firmware/compile
+++ b/firmware/compile
@@ -1,0 +1,24 @@
+gcc -Wall -g -c pixlar.c -o pixlar.o
+ar rsv pixlar.a pixlar.o
+gcc dump_loop.c -o dump_loop pixlar.a
+gcc send_loopA.c -o send_loopA pixlar.a
+gcc send_loopB.c -o send_loopB pixlar.a
+gcc send_loopC.c -o send_loopC pixlar.a
+gcc send_loopD.c -o send_loopD pixlar.a
+gcc pixlar_readA.c -o pixlar_readA pixlar.a
+gcc pixlar_readB.c -o pixlar_readB pixlar.a
+gcc pixlar_readC.c -o pixlar_readC pixlar.a
+gcc pixlar_readD.c -o pixlar_readD pixlar.a
+gcc pixlar_write_config.c -o pixlar_write_config pixlar.a
+gcc pixlar_write_disableall.c -o pixlar_write_disableall pixlar.a
+gcc pixlar_write_enableall.c -o pixlar_write_enableall pixlar.a
+gcc pixlar_writeA.c -o pixlar_writeA pixlar.a
+gcc pixlar_writeB.c -o pixlar_writeB pixlar.a
+gcc pixlar_writeC.c -o pixlar_writeC pixlar.a
+gcc pixlar_writeD.c -o pixlar_writeD pixlar.a
+gcc rgbled.c -o rgbled pixlar.a
+gcc -o pixlar_dataserver pixlar_dataserver.c pixlar.a -lzmq -std=gnu99 -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+gcc -o pixlar_cmdserver pixlar_cmdserver.c pixlar.a -lzmq -std=gnu99 -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+gcc -o pixlar_store pixlar_store.c pixlar.a -lzmq -std=gnu99 -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+gcc -o pixlar_ctl pixlar_ctl.c pixlar.a -lzmq -std=gnu99 -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+

--- a/firmware/pixlar
+++ b/firmware/pixlar
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+sleep 5
+sudo nohup /home/ubuntu/pixlar_cmdserver >/dev/null 2>&1 &
+sudo nohup /home/ubuntu/pixlar_dataserver >/dev/null 2>&1 &
+
+exit 0

--- a/firmware/pixlar_cmdserver.c
+++ b/firmware/pixlar_cmdserver.c
@@ -1,0 +1,139 @@
+#include <zmq.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <arpa/inet.h>
+#include <linux/if_packet.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/ether.h>
+#include <sys/timeb.h>
+#include "pixlar.h"
+#include <time.h>
+
+void *context = NULL;
+
+//  Socket to respond to clients
+void *responder = NULL;
+struct timeb mstime0, mstime1;
+uint64_t  nstarts=0, nstops=0;
+char dummy[256];
+
+void printdate()
+{
+    char str[64];
+    time_t result=time(NULL);
+    sprintf(str,"%s", asctime(gmtime(&result))); 
+    str[strlen(str)-1]=0; //remove CR simbol
+    printf("%s ", str); 
+}
+
+int SetFreq(int freq)
+{
+  setCLKx2(freq);
+  return 1;
+}
+
+int SetTestFreq(int divider)
+{
+ // setCLKx2(freq);
+  setCLKTestPulse(divider);
+  return 1;
+}
+
+
+int SendWord(uint64_t wd, int chan)
+{
+  if(chan<0)
+ {
+  printf("ASIC: sending to all channels ");
+    dumpc(wd);
+  uart54_send(0, &wd, 1);
+  uart54_send(1, &wd, 1);
+  uart54_send(2, &wd, 1);
+  uart54_send(3, &wd, 1);
+ }
+ else
+ {
+  printf("ASIC: sending to channel %d ",chan);
+    dumpc(wd);
+  uart54_send(chan, &wd, 1);
+ }
+  return 1;
+}
+
+
+int main (int argc, char **argv)
+{
+
+int rv;
+context = zmq_ctx_new();
+
+//  Socket to respond to clients
+responder = zmq_socket (context, ZMQ_REP);
+rv=zmq_bind (responder, "tcp://*:5555");
+if(rv<0) {printdate(); printf("Can't bind tcp socket for command! Exiting.\n"); return 0;}
+printdate(); printf ("pixlar_server: listening at tcp://5555\n");
+
+
+zmq_msg_t request;
+
+char cmd[32]; //command string
+uint64_t arg=0;
+int arg2=0;
+int args=0;
+
+while (1) {  // main loop
+
+//Check next request from client
+zmq_msg_init (&request);
+//if(zmq_msg_recv (&request, responder, ZMQ_DONTWAIT)==-1) {zmq_msg_close (&request);  polldata(); senddata(); sendstats(); sendstats2(); usleep(polldelay*1000); continue;} 
+if(zmq_msg_recv (&request, responder, ZMQ_DONTWAIT)==-1) continue; 
+memcpy(cmd,(char*)zmq_msg_data(&request),7); cmd[7]=0;
+
+//arg=strtoull((char*)(zmq_msg_data(&request)+8), NULL, 0);
+args=sscanf((char*)(zmq_msg_data(&request)+8),"%llx %d",&arg,&arg2);
+if(args<2) arg2=-1; //no channel indicated
+printdate(); printf ("Received Command %s arg=0x%llx (decimal %lld) arg2=%d \n",cmd, arg, arg, arg2 );
+rv=0;
+ if(strcmp(cmd, "SETFREQ")==0) rv=SetFreq((int)arg); //get 8-th byte of message - start of argument
+ else if (strcmp(cmd, "SETFTST")==0) rv=SetTestFreq((int)arg); //set frequency divider of the test pulse (from master clock)
+ else if (strcmp(cmd, "SNDWORD")==0) rv=SendWord(arg,arg2);
+ else if (strcmp(cmd, "SYRESET")==0) rv=system_reset();
+ else if (strcmp(cmd, "GETSTAT")==0) rv=uart54_getstats(arg, &nstarts, &nstops);
+ else if (strcmp(cmd, "SETCONF")==0) ;//rv=configu(*(uint8_t*)(zmq_msg_data(&request)+8), (uint8_t*)(zmq_msg_data(&request)+9), zmq_msg_size (&request)-9); 
+ else if (strcmp(cmd, "GET_SCR")==0) ;//rv=getSCR(*(uint8_t*)(zmq_msg_data(&request)+8),buf); 
+ else if (strcmp(cmd, "PING_HB")==0)  rv=1;//Link integrity test - Do nothing, just send OK
+
+//  Send reply back to client
+zmq_msg_t reply;
+
+if (strcmp(cmd, "GETSTAT")==0)
+{
+  sprintf(dummy, "%lld %lld",nstarts,nstops);
+  zmq_msg_init_size (&reply, strlen(dummy)+1);
+  sprintf(zmq_msg_data (&reply), "%s",dummy);
+}
+else
+{
+ zmq_msg_init_size (&reply, 5);
+ if(rv>0) sprintf(zmq_msg_data (&reply), "OK");
+ else sprintf(zmq_msg_data (&reply), "ERR");
+} 
+printf("Sending reply %s\n",(char*)zmq_msg_data (&reply));
+zmq_msg_send (&reply, responder, 0);
+zmq_msg_close (&reply);
+
+} //end main loop
+
+
+return 0;
+}
+
+

--- a/firmware/pixlar_dataserver.c
+++ b/firmware/pixlar_dataserver.c
@@ -1,0 +1,143 @@
+
+#include <zmq.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <arpa/inet.h>
+#include <linux/if_packet.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <stdio.h>
+#include <termios.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/ether.h>
+#include <sys/timeb.h>
+#include "pixlar.c"
+#include <time.h>
+
+
+void *context = NULL;
+
+//  Socket to send data to clients
+void *publisher = NULL;
+
+struct timeb mstime0, mstime1;
+time_t ct,ct0;
+
+uint8_t evbuf[EVLEN];
+
+volatile int bufbusy=0;
+
+
+void transfer_complete (void *data, void *hint) //call back from ZMQ sent function, hint points to subbufer index
+{
+bufbusy=0;
+// printf("buf transmission complete.\n");
+}
+
+
+void sendout(void * evbuf, int bytes)
+{
+int rv;
+zmq_msg_t msg;
+zmq_msg_init_data (&msg, evbuf, bytes , transfer_complete, NULL);
+//printf("sendout() buf for sending..\n");
+rv=zmq_msg_send (&msg, publisher, ZMQ_DONTWAIT);
+if(rv==-1) {rv=zmq_errno(); printf("zmq_msg_send ERRNO=%d\n",rv);}
+//printf("zmq_msg_send returns %d\n",rv);
+//zmq_msg_close (&msg); - according to manual not needed
+}
+
+void printdate()
+{
+    char str[64];
+    time_t result=time(NULL);
+    sprintf(str,"%s", asctime(gmtime(&result))); 
+    str[strlen(str)-1]=0; //remove CR simbol
+    printf("%s ", str); 
+}
+
+/*
+ZMQ_TCP_KEEPALIVE -> 1,
+ZMQ_TCP_KEEPALIVE_CNT -> 4,
+ZMQ_TCP_KEEPALIVE_INTVL -> 15,
+ZMQ_TCP_KEEPALIVE_IDLE -> 60,
+ZMQ_SNDHWM -> 10000,
+ZMQ_SNDBUF -> 256*10000,
+ZMQ_LINGER -> 0,
+ZMQ_SNDTIMEO - > 3000,
+*/
+
+
+int main (int argc, char **argv)
+{
+
+ //   set_conio_terminal_mode();
+char roll[4]={95,92,124,47};
+int rv;
+uint64_t buf[1024];
+char heartbeat[128];
+sprintf(heartbeat,"HB");
+
+uint64_t w64;
+context = zmq_ctx_new();
+long long unsigned rec_wA=0, rec_wB=0, rec_wC=0, rec_wD=0;
+//  Socket to send data to clients
+publisher = zmq_socket (context, ZMQ_PUB);
+/*
+int64_t affinity;
+affinity = 1;
+rc = zmq_setsockopt (socket, ZMQ_AFFINITY, &affinity, sizeof affinity);
+assert (rc);
+*/
+int64_t hwm = 100;
+zmq_setsockopt (publisher, ZMQ_SNDHWM, &hwm, sizeof hwm);
+int64_t sndbuf = 200*EVLEN;
+zmq_setsockopt (publisher, ZMQ_SNDBUF, &sndbuf, sizeof sndbuf);
+int ling = 1;
+zmq_setsockopt (publisher, ZMQ_LINGER, &ling, sizeof ling);
+int timeout = 250;
+zmq_setsockopt (publisher, ZMQ_SNDTIMEO, &timeout, sizeof timeout);
+
+rv = zmq_bind (publisher, "tcp://*:5556");
+if(rv<0) {printdate(); printf("Can't bind tcp socket for data! ERRNO=%d. Exiting.\n",errno); return 0;}
+printdate(); printf ("pixlar_server: data publisher at tcp://5556\n");
+bufbusy=0;
+
+
+    int fd[4];
+    fd[0] = open("/dev/uart640", O_RDWR); printf("open /dev/uart640 fd=%d\n",fd[0]);
+    fd[1] = open("/dev/uart641", O_RDWR); printf("open /dev/uart641 fd=%d\n",fd[1]);
+    fd[2] = open("/dev/uart642", O_RDWR); printf("open /dev/uart642 fd=%d\n",fd[2]);
+    fd[3] = open("/dev/uart643", O_RDWR); printf("open /dev/uart643 fd=%d\n",fd[3]);
+
+int recvd=0;
+ct0=time(NULL);
+while(1) //main loop
+{
+    if(bufbusy==0){    recvd=read(fd[0],buf,1024*8);    rec_wA=rec_wA+recvd/8; if(recvd>0) {   bufbusy=1;   sendout(buf,recvd); ct0=time(NULL);}}
+    if(bufbusy==0){    recvd=read(fd[1],buf,1024*8);    rec_wB=rec_wB+recvd/8; if(recvd>0) {   bufbusy=1;   sendout(buf,recvd); ct0=time(NULL);}}
+    if(bufbusy==0){    recvd=read(fd[2],buf,1024*8);    rec_wC=rec_wC+recvd/8; if(recvd>0) {   bufbusy=1;   sendout(buf,recvd); ct0=time(NULL);}}
+    if(bufbusy==0){    recvd=read(fd[3],buf,1024*8);    rec_wD=rec_wD+recvd/8; if(recvd>0) {   bufbusy=1;   sendout(buf,recvd); ct0=time(NULL);}}
+     
+//    if(recvd>0) printf("Received words:  A:%lld B:%lld C:%lld D:%lld \n",rec_wA, rec_wB,rec_wC, rec_wD);
+
+//Heartbeat generation if no data
+ct=time(NULL);
+if(ct-ct0 > 1 && bufbusy==0) {ct0=ct; sendout(heartbeat,3);}
+
+}
+
+close(fd[0]);
+close(fd[1]);
+close(fd[2]);
+close(fd[3]);
+return 0;
+}
+
+
+

--- a/firmware/pixlar_store.c
+++ b/firmware/pixlar_store.c
@@ -1,0 +1,90 @@
+/// prints out statistics from FEB driver
+#include <zmq.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+FILE *fp;
+
+void usage()
+{
+ printf("Connects to data stream from running pixlar_dataserver at a given data socket and stores (adds) data in a file.\n Usage: ");
+// printf("pixlar_store <socket> <filename>\n");
+ printf("pixlar_store <socket> <filename>  <max events>\n");
+ printf("If <filename> is omitted, outputs data to stdout.\n");
+ printf("<max events> is maximum number of polls per file. If reached, the index in file name increments. Optional, set to 10000 by default. \n");
+ printf("Interface example:  tcp://localhost:5556 \n");
+
+}
+
+int main (int argc, char **argv)
+{
+int rv;
+char * iface;
+char filename[128];
+char sim[4]={'|','/','-','\\'};
+int isim=0;
+time_t t0,t1;
+int dt,dt0;
+int polls, maxpolls, findex;
+if(argc<2 || argc>4) { usage(); return 0;}
+iface=argv[1];
+//filename=argv[2];
+findex=1; polls=0;
+if(argc>2) sprintf(filename,"%s.%d",argv[2],findex);
+if(argc==4) maxpolls=atoi(argv[3]); else maxpolls=10000;
+if(argc>2) fp=fopen(filename,"a"); 
+void * context = zmq_ctx_new ();
+//  Socket to talk to server
+printf ("Connecting to pixlar_dataserver at %s...\n",iface);
+void *subscriber = zmq_socket (context, ZMQ_SUB);
+if(subscriber<=0) { printf("Can't initialize the socket!\n"); return 0;}
+rv=zmq_connect (subscriber, iface);
+if(rv<0) { printf("Can't connect to the socket!\n"); return 0;}
+//zmq_connect (subscriber, "ipc://stats");
+rv=zmq_setsockopt (subscriber, ZMQ_SUBSCRIBE, NULL, 0);
+if(rv<0) { printf("Can't set SUBSCRIBE option to the socket!\n"); return 0;}
+printf("0"); fflush(stdout);
+while(1)
+{
+zmq_msg_t reply;
+zmq_msg_init (&reply);
+t0=time(NULL);
+dt=0; dt0=0;
+while(zmq_msg_recv (&reply, subscriber, ZMQ_DONTWAIT)==-1)
+ {
+  dt=time(NULL)-t0; 
+  if(dt>2 && dt!=dt0) {
+                      printf("No data from driver for %d seconds!\n",dt); 
+                      dt0=dt;
+  }
+ };
+if(argc==2) printf ("%0llx\n", *(long long unsigned int*)(zmq_msg_data (&reply)));
+if(argc>2) 
+  {
+   printf("\b%c",sim[isim]); fflush(stdout); if(isim<3) isim++; else isim=0;
+   fwrite((char*)(zmq_msg_data(&reply)),zmq_msg_size(&reply) , 1, fp);
+   fflush(fp);
+  } 
+zmq_msg_close (&reply);
+polls++;
+
+if(polls>maxpolls) 
+  {
+    polls=0;
+    findex++;
+    fclose(fp);
+    sprintf(filename,"%s.%d",argv[2],findex);
+    fp=fopen(filename,"a"); 
+  }
+  
+}
+zmq_close (subscriber);
+zmq_ctx_destroy (context);
+if(argc>2) fclose(fp);
+return 0;
+}
+

--- a/firmware/pixlar_write_disableall.c
+++ b/firmware/pixlar_write_disableall.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "pixlar.h"
+
+
+
+int main(int argc, char *argv[]) {
+
+    if(argc!=4) {printf("usage: sudo ./pixlar_disable_all start end channel\n"); return 0; }
+    uint64_t chipid,reg,data, chip0, chip1,par,channel;
+    chip0= strtof(argv[1],0);    
+    chip1= strtof(argv[2],0);    
+    channel= strtof(argv[3],0);    
+    uint64_t wrd64= 0; //strtoull(argv[1], NULL, 0);
+    data=255; //disable all channels
+for( chipid=chip0; chipid<=chip1; chipid++)
+for( reg=52; reg<=55; reg++)
+ { 
+    wrd64=2;
+    wrd64=wrd64 | (chipid<<2);
+    wrd64=wrd64 | (reg<<10);
+    wrd64=wrd64 | (data<<18);
+    par=parity(wrd64);
+    wrd64=wrd64 | (par<<53);
+
+    dumpc(wrd64);
+/*
+    uart54_send(0, &wrd64, 1);
+    usleep(10000);
+    uart54_send(1, &wrd64, 1);
+    usleep(10000);
+    uart54_send(2, &wrd64, 1);
+    usleep(10000);
+    uart54_send(3, &wrd64, 1);
+    usleep(10000);
+*/
+    uart54_send(channel, &wrd64, 1);
+
+}
+    return 1;
+   
+
+/*
+    off_t offset = UART54_B_SEND;
+    size_t len = 8;
+
+    // Truncate offset to a multiple of the page size, or mmap will fail.
+    size_t pagesize = sysconf(_SC_PAGE_SIZE);
+    off_t page_base = (offset / pagesize) * pagesize;
+    off_t page_offset = offset - page_base;
+
+    int fd = open("/dev/mem", O_RDWR | O_SYNC);
+    volatile unsigned char *mem = mmap(NULL, page_offset + len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, page_base);
+    if (mem == MAP_FAILED) {
+        perror("Can't map memory");
+        return -1;
+    }
+
+    size_t i;
+    while( *(mem+page_offset+7)<0x80) {}
+    *((volatile uint64_t*)(mem+page_offset))=wrd64;
+
+    return 0;
+*/
+}

--- a/firmware/setup
+++ b/firmware/setup
@@ -1,0 +1,43 @@
+
+#busybox devmem 0x43c00000 32 49   #2.. MHz
+#busybox devmem 0x43c00000 32 4   #20.0 MHz
+busybox devmem 0x43c00000 32 9   #10.0 MHz
+busybox devmem 0x43c00004 32 1   #Reset
+busybox devmem 0x43c00004 32 0   #Reset
+
+#busybox devmem 0x43c00008 32 100000   #100 Hz at TST output LEMO
+busybox devmem 0x43c00008 32 10000   #1000 Hz at TST output LEMO
+busybox devmem 0xF8000180 32 0x00100500 //set FCLCK1 to 100 MHz
+#busybox devmem 0xF8000180 32 0x00100600 //set FCLCK1 to 100*5/6 MHz
+
+
+insmod /home/ubuntu/DriversWork/uart64n/uart64.ko
+sleep 1
+chmod 666 /dev/uart*
+
+#/home/ubuntu/pixlar_write_disableall 207 207
+#/home/ubuntu/pixlar_write_disableall 250 250
+#/home/ubuntu/pixlar_write_disableall 249 249
+
+
+#/home/ubuntu/silence
+#/home/ubuntu/silence
+
+
+
+
+#sudo busybox devmem 0x43c01020 64 1 
+#sudo busybox devmem 0x43c02020 64 1 
+#sudo busybox devmem 0x43c03020 64 1 
+#sudo busybox devmem 0x43c04020 64 1 
+
+
+
+#ifconfig eth0 130.92.139.27 netmask 255.255.255.0 broadcast 130.92.139.255  gateway 130.92.139.1
+#ifdown eth0; ifup eth0;
+
+/home/ubuntu/pixlar &
+sleep 1
+/home/ubuntu/silence
+sleep 1
+/home/ubuntu/silence

--- a/firmware/silence
+++ b/firmware/silence
@@ -1,0 +1,53 @@
+# PCB-1
+./pixlar_write_disableall 246 246 0
+./pixlar_write_disableall 245 245 0
+./pixlar_write_disableall 252 252 0
+./pixlar_write_disableall 243 243 0
+
+#PCB-10
+./pixlar_write_disableall 207 207 0
+./pixlar_write_disableall 250 250 0
+./pixlar_write_disableall 249 249 0
+
+./pixlar_write_disableall 207 207 1
+./pixlar_write_disableall 250 250 1
+./pixlar_write_disableall 249 249 1
+
+./pixlar_write_disableall 3 3 0
+./pixlar_write_disableall 5 5 0
+./pixlar_write_disableall 6 6 0
+./pixlar_write_disableall 9 9 0
+./pixlar_write_disableall 10 10 0
+./pixlar_write_disableall 12 12 0
+
+./pixlar_write_disableall 63 63 0
+./pixlar_write_disableall 60 60 0
+./pixlar_write_disableall 58 58 0
+./pixlar_write_disableall 54 54 0
+./pixlar_write_disableall 57 57 0
+./pixlar_write_disableall 53 53 0
+./pixlar_write_disableall 51 51 0
+./pixlar_write_disableall 48 48 0
+
+./pixlar_write_disableall 80 80 1
+./pixlar_write_disableall 83 83 1
+./pixlar_write_disableall 85 85 1
+./pixlar_write_disableall 86 86 1
+./pixlar_write_disableall 89 89 1
+./pixlar_write_disableall 90 90 1
+./pixlar_write_disableall 92 92 1
+./pixlar_write_disableall 95 95 1
+
+./pixlar_write_disableall 99 99 1
+./pixlar_write_disableall 101 101 1
+./pixlar_write_disableall 102 102 1
+./pixlar_write_disableall 105 105 1
+./pixlar_write_disableall 106 106 1
+./pixlar_write_disableall 108 108 1
+
+
+#3,  5,  6,  9, 10, 12,
+# 63, 60, 58, 54, 57, 53, 51, 48,
+# 80, 83, 85, 86, 89, 90, 92, 95,
+#     99,101,102,105,106,108,
+


### PR DESCRIPTION
from my original pull request:

> Hi Igor,
> 
> I added the ZMQ protocol that I sent you to the repository. I also added the pixlar scripts that live on the SD card.
> 
> The last commit I made (04c0b41) has the changes I was suggesting over email - that the ZMQ messages from the data server are labeled based on which MISO channel they came from. I'm not great at C programming so I hope my intent is clear: beginning each ZMQ message with a "data version" followed by the IO channel index (0 through 3) followed by the data itself. If there's a better way to accomplish the same thing I welcome your assistance.
> 
> Sam